### PR TITLE
Fix #8: fix goreleaser version update during  build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,10 @@
-# x.x.x
+# Changelog
+
+## 1.0.1
+
+* Build docker image for tags
+* Fix #8: update release version during build
+
+## 1.0.0
+
 * Migrated existing functionality from private repository

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ import (
 
 var (
 	// VERSION is set during build
-	VERSION = "0.0.1"
+	version = "0.0.1"
 )
 
 func main() {
-	cmd.Execute(VERSION)
+	cmd.Execute(version)
 }


### PR DESCRIPTION
Go release uses `env` variable `main.version` while we had `main.VERSION` so the version was not updated during  build process. see [here](https://goreleaser.com/environment/#using-the-mainversion)