### PR TITLE
Standardize the release project name, binary and release.github.name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+vendor
+dist
+
+# Output of the go coverage tool
+*.out
+cover-report.html
+coverage.txt
+cover.html
+
+/nova
+/Nova
+pkged.go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,8 @@
 project_name: nova
+release:
+  github:
+    owner: FairwindsOps
+    name: nova
 builds:
   - id: nova
     binary: nova

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
+project_name: nova
 builds:
   - id: nova
+    binary: nova
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ changelog:
       - '^test:'
 brews:
   - name: nova
-    github:
+    tap:
       owner: FairwindsOps
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
I think before changing to `nova` this was called `Nova` and .goleaser uses that [old reference ](https://goreleaser.com/customization/project/) to create a new release. Just explicitly defined those in .goleaser so the binary should be standard.

also https://goreleaser.com/deprecations#brewsgithub

Closes #21 