### PR TITLE
Support passing kubeContext.

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -29,11 +29,15 @@ var (
 	pollHelmHub      bool
 	helmHubConfigURL string
 	wide             bool
+	kubeconfig       string
+	kubeContext      string
 )
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
 	rootCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "", "", "Path on local filesystem to write file output to")
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "The location of a kubeconfig file to use.")
+	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "A context to use in the kubeconfig.")
 	clusterCmd.PersistentFlags().StringVar(&helmVersion, "helm-version", "3", "Helm version in the current cluster (2|3|auto)")
 	clusterCmd.PersistentFlags().BoolVar(&wide, "wide", false, "Output chart name and namespace")
 
@@ -67,8 +71,9 @@ var clusterCmd = &cobra.Command{
 	Long:  "Find deployed helm releases that have updated charts available in chart repos",
 	Run: func(cmd *cobra.Command, args []string) {
 
+		h := nova_helm.NewHelm(helmVersion, &kubeContext)
 		HelmRepos := nova_helm.NewRepo(getRepoURLs())
-		outputObjects, err := nova_helm.GetReleaseOutput(helmVersion, HelmRepos)
+		outputObjects, err := h.GetReleaseOutput(HelmRepos)
 		out := output.Output{outputObjects}
 
 		if err != nil {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -29,14 +29,12 @@ var (
 	pollHelmHub      bool
 	helmHubConfigURL string
 	wide             bool
-	kubeconfig       string
 	kubeContext      string
 )
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
 	rootCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "", "", "Path on local filesystem to write file output to")
-	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "The location of a kubeconfig file to use.")
 	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "A context to use in the kubeconfig.")
 	clusterCmd.PersistentFlags().StringVar(&helmVersion, "helm-version", "3", "Helm version in the current cluster (2|3|auto)")
 	clusterCmd.PersistentFlags().BoolVar(&wide, "wide", false, "Output chart name and namespace")

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -71,10 +71,12 @@ var clusterCmd = &cobra.Command{
 	Long:  "Find deployed helm releases that have updated charts available in chart repos",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		h := nova_helm.NewHelm(helmVersion, &kubeContext)
+		h := nova_helm.NewHelm(helmVersion, kubeContext)
 		HelmRepos := nova_helm.NewRepo(getRepoURLs())
 		outputObjects, err := h.GetReleaseOutput(HelmRepos)
-		out := output.Output{outputObjects}
+		out := output.Output{
+			HelmReleases: outputObjects,
+		}
 
 		if err != nil {
 			klog.Fatalf("Error getting helm releases from cluster: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,8 +30,8 @@ var (
 
 func init() {
 	klog.InitFlags(nil)
-	flag.Set("alsologtostderr", "true")
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("alsologtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 	flag.Parse()
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }

--- a/pkg/helm/cluster.go
+++ b/pkg/helm/cluster.go
@@ -33,7 +33,7 @@ type Helm struct {
 }
 
 // NewHelm returns a basic helm struct with the version of helm requested
-func NewHelm(version string, kubeContext *string) *Helm {
+func NewHelm(version string, kubeContext string) *Helm {
 	return &Helm{
 		Version: version,
 		Kube:    getConfigInstance(kubeContext),

--- a/pkg/helm/cluster.go
+++ b/pkg/helm/cluster.go
@@ -26,17 +26,17 @@ import (
 	"k8s.io/klog"
 )
 
-// Helm represents all current releases that we can find in the cluster
+// Helm contains a helm version and kubernetes client interface
 type Helm struct {
 	Version string
 	Kube    *kube
 }
 
 // NewHelm returns a basic helm struct with the version of helm requested
-func NewHelm(version string) *Helm {
+func NewHelm(version string, kubeContext *string) *Helm {
 	return &Helm{
 		Version: version,
-		Kube:    getConfigInstance(),
+		Kube:    getConfigInstance(kubeContext),
 	}
 }
 
@@ -126,24 +126,19 @@ func (h *Helm) GetHelmReleasesVersion2(helmRepos []*Repo) ([]output.ReleaseOutpu
 }
 
 // GetReleaseOutput return the expected output or error
-func GetReleaseOutput(version string, repos []*Repo) (outputObjects []output.ReleaseOutput, err error) {
-
-	switch version {
+func (h *Helm) GetReleaseOutput(repos []*Repo) (outputObjects []output.ReleaseOutput, err error) {
+	switch h.Version {
 	case "2":
-		h := NewHelm(version)
 		outputObjects, err = h.GetHelmReleasesVersion2(repos)
 	case "3":
-		h := NewHelm(version)
 		outputObjects, err = h.GetHelmReleasesVersion3(repos)
 	case "auto":
-		h := NewHelm("3")
 		outputObjectsVersion3, err3 := h.GetHelmReleasesVersion3(repos)
 		if outputObjectsVersion3 != nil {
 			outputObjects = append(outputObjects, outputObjectsVersion3...)
 		}
-		h2 := NewHelm("2")
 
-		outputObjectsVersion2, err2 := h2.GetHelmReleasesVersion2(repos)
+		outputObjectsVersion2, err2 := h.GetHelmReleasesVersion2(repos)
 		if outputObjectsVersion2 != nil {
 			outputObjects = append(outputObjects, outputObjectsVersion2...)
 		}

--- a/pkg/helm/kube.go
+++ b/pkg/helm/kube.go
@@ -34,7 +34,7 @@ var kubeClient *kube
 var once sync.Once
 
 // GetConfigInstance returns a Kubernetes interface based on the current configuration
-func getConfigInstance(context *string) *kube {
+func getConfigInstance(context string) *kube {
 	once.Do(func() {
 		if kubeClient == nil {
 			kubeClient = &kube{
@@ -45,24 +45,18 @@ func getConfigInstance(context *string) *kube {
 	return kubeClient
 }
 
-func getKubeClient(context *string) kubernetes.Interface {
+func getKubeClient(context string) kubernetes.Interface {
 	var clientset *kubernetes.Clientset
 
-	kubeConf, err := config.GetConfigWithContext(*context)
+	kubeConf, err := config.GetConfigWithContext(context)
 	if err != nil {
-		klog.Errorf("error getting config with context %s: %v", *context, err)
+		klog.Errorf("error getting config with context %s: %v", context, err)
 		os.Exit(1)
 	}
-	// if context == nil {
-	// 	kubeConf, err := config.GetConfig()
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// }
 
 	clientset, err = kubernetes.NewForConfig(kubeConf)
 	if err != nil {
-		klog.Errorf("error create kubernetes client: %v", *context, err)
+		klog.Errorf("error create kubernetes client: %v", err)
 		os.Exit(1)
 	}
 	return clientset


### PR DESCRIPTION
Fixes #7 

This PR also refactors some of the logic with how the Helm object is used. This was done in order to get Nova to fail faster when passing a kube config or context that cannot connect to the cluster. Essentially, I realized that the `Version` was only used to determine which GetReleases function to call, so I made `GetReleaseOutput` a method of `Helm`. The means that the client is created first, before scanning any upstream repositories for version.

A couple other small changes were made for golangci-lint to pass

Example use and output:

I have two available contexts, and the currently set one is `kind-kind`. Notice the output is different for the two `find` runs. The third one shows what happens when you don't pass a context (it uses the currently set context)
```
▶ k config get-contexts
CURRENT   NAME        CLUSTER     AUTHINFO    NAMESPACE
          kind-kind   kind-kind   kind-kind
*         kind-test   kind-test   kind-test

▶ ./nova find --context kind-kind
Release Name      Installed    Latest    Old      Deprecated
metrics-server    5.3.3        5.3.3     false    false

▶ ./nova find --context kind-test
No releases found
Release Name    Installed    Latest    Old    Deprecated

▶ ./nova find
No releases found
Release Name    Installed    Latest    Old    Deprecated
```

Now if the context doesn't exist:

```
▶ ./nova find --context=blerg
E0115 11:38:20.210987   88787 kube.go:53] error getting config with context blerg: could not locate a kubeconfig
```
