### PR TITLE
Update build and release processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,32 @@ version: 2.1
 orbs:
   rok8s: fairwinds/rok8s-scripts@11
 
+references:
+  enable_experimental_features: &enable_experimental_docker_features
+    run:
+      name: enable experimental features
+      command: |
+        set -ex
+        apk --update add openssh
+        ssh remote-docker \<<EOF
+          sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+          sudo systemctl restart docker
+        EOF
+  install_vault: &install_vault
+    run:
+      name: install hashicorp vault
+      command: |
+        apk --update add curl yq
+        cd /tmp
+        curl -LO https://releases.hashicorp.com/vault/1.9.2/vault_1.9.2_linux_amd64.zip
+        unzip vault_1.9.2_linux_amd64.zip
+        mv vault /usr/bin/vault
+
 jobs:
   test:
     working_directory: /go/src/github.com/fairwindsops/nova
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - run:
@@ -24,20 +45,37 @@ jobs:
             go tool cover -html=coverage.txt -o cover-report.html
   snapshot:
     working_directory: /go/src/github.com/fairwindsops/nova
+    resource_class: large
     docker:
-      - image: goreleaser/goreleaser:v0.174.2
+      - image: goreleaser/goreleaser:v1.3.0
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.6
+      - *enable_experimental_docker_features
       - run: goreleaser --snapshot
       - store_artifacts:
           path: dist
           destination: snapshot
-  release-binary:
+  release:
     working_directory: /go/src/github.com/fairwindsops/nova
+    resource_class: large
+    shell: /bin/bash
     docker:
-      - image: goreleaser/goreleaser:v0.174.2
+      - image: goreleaser/goreleaser:v1.3.0
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.6
+      - *enable_experimental_docker_features
+      - *install_vault
+      - rok8s/get_vault_env:
+          vault_path: repo/global/env
+      - rok8s/docker_login:
+          registry: "quay.io"
+          username: $FAIRWINDS_QUAY_USER
+          password-variable: FAIRWINDS_QUAY_TOKEN
+      - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
   publish_docs:
     docker:
@@ -53,11 +91,29 @@ jobs:
             npm run check-links
             npm run build
       - run:
-          name: Install AWS CLI
+          name: Install Tools
           command: |
+            cd /tmp
+            echo "Installing AWS CLI"
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
             sudo ./aws/install
+
+            echo "Installing Hashicorp Vault"
+            curl -LO https://releases.hashicorp.com/vault/1.9.2/vault_1.9.2_linux_amd64.zip
+            unzip vault_1.9.2_linux_amd64.zip
+            sudo mv vault /usr/bin/vault
+            sudo chmod +x /usr/bin/vault
+            vault --version
+
+            echo "Installing yq"
+            curl -LO https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64.tar.gz
+            tar -zxvf yq_linux_amd64.tar.gz
+            sudo mv yq_linux_amd64 /usr/bin/yq
+            sudo chmod +x /usr/bin/yq
+            yq --version
+      - rok8s/get_vault_env:
+          vault_path: repo/nova/env
       - run:
           name: Publish Docs Site to S3
           command: |
@@ -77,35 +133,6 @@ workflows:
               only: /.*/
             tags:
               ignore: /.*/
-      - rok8s/docker_build_and_push:
-          name: build-container
-          docker-push: false
-          password-variable: "fairwinds_quay_token"
-          enable_docker_layer_caching: true
-          config_file: .circleci/build.config
-          requires:
-            - test
-          filters:
-            branches:
-              only: /pull\/[0-9]+/
-      - rok8s/docker_build_and_push:
-          name: build-and-push-container
-          docker-push: true
-          enable_docker_layer_caching: true
-          config_file: .circleci/build.config
-          context: org-global
-          docker-login: true
-          password-variable: "fairwinds_quay_token"
-          registry: quay.io
-          username: fairwinds+circleci
-          requires:
-            - test
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-            tags:
-              ignore: /.*/
-
   release:
     jobs:
       - publish_docs:
@@ -114,23 +141,8 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      - release-binary:
+      - release:
           context: org-global
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-      - rok8s/docker_build_and_push:
-          name: build-and-push-container
-          docker-push: true
-          enable_docker_layer_caching: false
-          config_file: .circleci/build.config
-          context: org-global
-          docker-login: true
-          password-variable: "fairwinds_quay_token"
-          registry: quay.io
-          username: fairwinds+circleci
           filters:
             branches:
               ignore: /.*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 project_name: nova
 release:
+  prerelease: auto
   github:
     owner: FairwindsOps
     name: nova
@@ -20,6 +21,9 @@ builds:
       - linux
       - darwin
       - windows
+    ignore:
+      - goos: windows
+        goarch: arm64
 checksum:
   name_template: 'checksums.txt'
 changelog:
@@ -37,3 +41,48 @@ brews:
     description: Check installed Helm charts for updates
     test: |
       system "#{bin}/nova version"
+
+dockers:
+- image_templates:
+  - "quay.io/fairwinds/nova:{{ .FullCommit }}-amd64"
+  - "quay.io/fairwinds/nova:{{ .Tag }}-amd64"
+  - "quay.io/fairwinds/nova:v{{ .Major }}-amd64"
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-amd64"
+  use: buildx
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "quay.io/fairwinds/nova:{{ .Tag }}-arm64v8"
+  - "quay.io/fairwinds/nova:v{{ .Major }}-arm64v8"
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-arm64v8"
+  use: buildx
+  goarch: arm64
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+- image_templates:
+  - "quay.io/fairwinds/nova:{{ .Tag }}-armv7"
+  - "quay.io/fairwinds/nova:v{{ .Major }}-armv7"
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-armv7"
+  use: buildx
+  goarch: arm64
+  dockerfile: Dockerfile
+  build_flag_templates:
+  - "--platform=linux/arm/v7"
+docker_manifests:
+- name_template: quay.io/fairwinds/nova:{{ .Tag }}
+  image_templates:
+  - "quay.io/fairwinds/nova:{{ .Tag }}-amd64"
+  - "quay.io/fairwinds/nova:{{ .Tag }}-arm64v8"
+  - "quay.io/fairwinds/nova:{{ .Tag }}-armv7"
+- name_template: quay.io/fairwinds/nova:v{{ .Major }}
+  image_templates:
+  - "quay.io/fairwinds/nova:v{{ .Major }}-amd64"
+  - "quay.io/fairwinds/nova:v{{ .Major }}-arm64v8"
+  - "quay.io/fairwinds/nova:v{{ .Major }}-armv7"
+- name_template: quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}
+  image_templates:
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-amd64"
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-arm64v8"
+  - "quay.io/fairwinds/nova:v{{ .Major }}.{{ .Minor }}-armv7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,5 @@
-FROM golang:1.15 AS build
-
-ARG version=dev
-ARG commit=none
-
-WORKDIR /go/src/github.com/fairwindsops/nova
-ADD . /go/src/github.com/fairwindsops/nova
-
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -a -o nova *.go
-RUN VERSION=$version COMMIT=$commit make build-linux
-
-
-FROM alpine:3.13 as alpine
-RUN apk --no-cache --update add ca-certificates tzdata && update-ca-certificates
-
-
 FROM scratch
-COPY --from=alpine /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=alpine /etc/passwd /etc/passwd
 
 USER nobody
-COPY --from=build /go/src/github.com/fairwindsops/nova/nova /
+COPY nova /
 CMD ["/nova"]

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ clean:
 # Cross compilation
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -s -w" -v
-build-docker:
-	docker build --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t quay.io/fairwinds/$(BINARY_NAME):dev .
+build-docker: build-linux
+	docker build -t quay.io/fairwinds/$(BINARY_NAME):dev .

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/fairwindsops/nova
 
-go 1.15
+go 1.17
 
 require (
-	// required for dependency issue: https://github.com/kubernetes/client-go/issues/628
-	github.com/Azure/go-autorest v12.2.0+incompatible
 	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/jmoiron/sqlx v1.2.0 // indirect
@@ -33,6 +31,49 @@ require (
 	k8s.io/helm v2.16.5+incompatible
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.5.2
+)
+
+require (
+	cloud.google.com/go v0.46.3 // indirect
+	github.com/Azure/go-autorest/autorest v0.9.0 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.5.0 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.1.0 // indirect
+	github.com/Azure/go-autorest/logger v0.1.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.5.0 // indirect
+	github.com/Masterminds/semver/v3 v3.0.3 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-logr/logr v0.1.0 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.3.1 // indirect
+	github.com/gophercloud/gophercloud v0.1.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
+	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 // indirect
+	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	gopkg.in/gorp.v1 v1.7.2 // indirect
+	gopkg.in/inf.v0 v0.9.0 // indirect
+	k8s.io/api v0.18.1 // indirect
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // FIXME: we shouldn't need a replace directive....

--- a/go.sum
+++ b/go.sum
@@ -15,9 +15,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-autorest v10.8.1+incompatible h1:u0jVQf+a6k6x8A+sT60l6EY9XZu+kHdnZVPAYqpVRo0=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
-github.com/Azure/go-autorest v12.2.0+incompatible h1:2Fxszbg492oAJrcvJlgyVaTqnQYRkxmEK6VPCLLVpBI=
-github.com/Azure/go-autorest v12.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
@@ -741,7 +740,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Update the release and build processes to use only goreleaser and secrets from Vault

### What changes did you make?
- updated the circle config to match Goldilocks and Pluto setup
- updated the version of goreleaser
- updated builds to go 1.17, including Dockerfile
- removed build of windows arm64 that didn't seem to work
- Publish multi-arch containers

### What alternative solution should we consider, if any?
n/a