### PR TITLE
Add User-Agent header for Artifacthub requests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,7 +166,7 @@ var clusterCmd = &cobra.Command{
 	Long:  "Find deployed helm releases that have updated charts available in chart repos",
 	Run: func(cmd *cobra.Command, args []string) {
 		h := nova_helm.NewHelm(viper.GetString("context"))
-		ahClient, err := nova_helm.NewArtifactHubPackageClient()
+		ahClient, err := nova_helm.NewArtifactHubPackageClient(version)
 		if err != nil {
 			klog.Fatalf("error setting up artifact hub client: %s", err)
 		}

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -178,7 +178,7 @@ func NewArtifactHubPackageClient(version string) (*ArtifactHubPackageClient, err
 		APIRoot:   apiRoot,
 		URL:       u,
 		Client:    client,
-		UserAgent: fmt.Sprintf("Nova/%s", version),
+		UserAgent: fmt.Sprintf("Fairwinds-Nova/%s ", version),
 	}, nil
 }
 

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -33,9 +33,10 @@ const (
 
 // ArtifactHubPackageClient provides the various pieces to interact with the ArtifactHub API.
 type ArtifactHubPackageClient struct {
-	APIRoot string
-	URL     *url.URL
-	Client  *http.Client
+	APIRoot   string
+	URL       *url.URL
+	Client    *http.Client
+	UserAgent string
 }
 
 // ArtifactHubPackageRepo is a simple struct to show a relationship between a helm package name and its repository.
@@ -166,7 +167,7 @@ type Link struct {
 }
 
 // NewArtifactHubPackageClient returns a new client for the unauthenticated paths of the ArtifactHub API.
-func NewArtifactHubPackageClient() (*ArtifactHubPackageClient, error) {
+func NewArtifactHubPackageClient(version string) (*ArtifactHubPackageClient, error) {
 	apiRoot := artifactHubAPIRoot
 	u, err := url.ParseRequestURI(apiRoot)
 	if err != nil {
@@ -174,9 +175,10 @@ func NewArtifactHubPackageClient() (*ArtifactHubPackageClient, error) {
 	}
 	client := new(http.Client)
 	return &ArtifactHubPackageClient{
-		APIRoot: apiRoot,
-		URL:     u,
-		Client:  client,
+		APIRoot:   apiRoot,
+		URL:       u,
+		Client:    client,
+		UserAgent: fmt.Sprintf("Nova/%s", version),
 	}, nil
 }
 
@@ -394,6 +396,7 @@ func (ac *ArtifactHubPackageClient) get(path string, urlValues url.Values) (*htt
 	}
 	r.URL.RawQuery = q.Encode()
 	r.Header.Add("accept", "application/json")
+	r.Header.Set("User-Agent", ac.UserAgent)
 	var response *http.Response
 	for attempt := 1; attempt <= 5; attempt++ {
 		resp, innerErr := ac.Client.Do(r)


### PR DESCRIPTION
This PR fixes issue #
N/A

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add a User-Agent header in the format of `Fairwinds-Nova/<VERSION>`
where VERSION is the version of Nova making the request.

### What changes did you make?
Send the version var into the ArtifactHubPackageClient and make
UserAgent a property of that struct. Construct the header in the
internal `get()` method.

### What alternative solution should we consider, if any?
Should the User-Agent string look different or have any other data
included?