### PR TITLE
Add back --url functionality and new --poll-artifacthub in lieu of --poll-helm-hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: lint
           command: |
-            go get -u golang.org/x/lint/golint
+            go install golang.org/x/lint/golint@latest
             golint -set_exit_status ./... | tee golint-report.out
             test -z $(go fmt ./...)
       - run:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -206,10 +206,9 @@ var clusterCmd = &cobra.Command{
 		if err != nil {
 			klog.Fatalf("error getting helm releases: %s", err)
 		}
+		out := output.NewOutputWithHelmReleases(releases)
+		out.IncludeAll = viper.GetBool("include-all")
 
-		out := output.Output{
-			IncludeAll: viper.GetBool("include-all"),
-		}
 		if viper.GetBool("poll-artifacthub") {
 			packageRepos, err := ahClient.MultiSearch(chartNames)
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,18 @@ func init() {
 		klog.Fatalf("Failed to bind desired-versions flag: %v", err)
 	}
 
+	rootCmd.PersistentFlags().StringSliceP("url", "u", []string{}, "URL for a helm chart repo")
+	err = viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("url"))
+	if err != nil {
+		klog.Fatalf("Failed to bind url flag: %v", err)
+	}
+
+	rootCmd.PersistentFlags().Bool("poll-artifacthub", true, "When true, polls artifacthub to match against helm releases in the cluster. If false, you must provide a url list via --url/-u. Default is true.")
+	err = viper.BindPFlag("poll-artifacthub", rootCmd.PersistentFlags().Lookup("poll-artifacthub"))
+	if err != nil {
+		klog.Fatalf("Failed to bind poll-artifacthub flag: %v", err)
+	}
+
 	rootCmd.PersistentFlags().String("context", "", "A context to use in the kubeconfig.")
 	err = viper.BindPFlag("context", rootCmd.PersistentFlags().Lookup("context"))
 	if err != nil {
@@ -165,13 +177,17 @@ var clusterCmd = &cobra.Command{
 	Short: "Find out-of-date deployed releases.",
 	Long:  "Find deployed helm releases that have updated charts available in chart repos",
 	Run: func(cmd *cobra.Command, args []string) {
+		if !viper.GetBool("poll-artifacthub") && len(viper.GetStringSlice("url")) == 0 {
+			klog.Fatalf("--poll-artifacthub=false requires urls provided to the --url flag. none were provided.")
+		}
+		klog.V(5).Infof("Settings: %v", viper.AllSettings())
+		klog.V(5).Infof("All Keys: %v", viper.AllKeys())
+
 		h := nova_helm.NewHelm(viper.GetString("context"))
 		ahClient, err := nova_helm.NewArtifactHubPackageClient(version)
 		if err != nil {
 			klog.Fatalf("error setting up artifact hub client: %s", err)
 		}
-		klog.V(5).Infof("Settings: %v", viper.AllSettings())
-		klog.V(5).Infof("All Keys: %v", viper.AllKeys())
 
 		if viper.IsSet("desired-versions") {
 			klog.V(3).Infof("desired-versions is set - attempting to load them")
@@ -190,22 +206,35 @@ var clusterCmd = &cobra.Command{
 		if err != nil {
 			klog.Fatalf("error getting helm releases: %s", err)
 		}
-		packageRepos, err := ahClient.MultiSearch(chartNames)
-		if err != nil {
-			klog.Fatalf("Error getting artifacthub package repos: %v", err)
-		}
-		packages := ahClient.GetPackages(packageRepos)
-		klog.V(2).Infof("found %d possible package matches", len(packages))
+
 		out := output.Output{
 			IncludeAll: viper.GetBool("include-all"),
 		}
-		for _, release := range releases {
-			o := nova_helm.FindBestArtifactHubMatch(release, packages)
-			if o != nil {
-				h.OverrideDesiredVersion(o)
-				out.HelmReleases = append(out.HelmReleases, *o)
+		if viper.GetBool("poll-artifacthub") {
+			packageRepos, err := ahClient.MultiSearch(chartNames)
+			if err != nil {
+				klog.Fatalf("Error getting artifacthub package repos: %v", err)
+			}
+			packages := ahClient.GetPackages(packageRepos)
+			klog.V(2).Infof("found %d possible package matches", len(packages))
+			for _, release := range releases {
+				o := nova_helm.FindBestArtifactHubMatch(release, packages)
+				if o != nil {
+					h.OverrideDesiredVersion(o)
+					out.HelmReleases = append(out.HelmReleases, *o)
+				}
 			}
 		}
+		if len(viper.GetStringSlice("url")) > 0 {
+			repos := viper.GetStringSlice("url")
+			helmRepos := nova_helm.NewRepos(repos)
+			outputObjects := h.GetHelmReleasesVersion(helmRepos, releases)
+			out.HelmReleases = append(out.HelmReleases, outputObjects...)
+			if err != nil {
+				klog.Fatalf("Error getting helm releases from cluster: %v", err)
+			}
+		}
+
 		outputFile := viper.GetString("output-file")
 		if outputFile != "" {
 			err = out.ToFile(outputFile)

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,12 @@ module github.com/fairwindsops/nova
 go 1.17
 
 require (
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/jmoiron/sqlx v1.3.1 // indirect
-	github.com/lib/pq v1.10.0 // indirect
-	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.1
 	k8s.io/apimachinery v0.22.3
 	k8s.io/client-go v0.22.3
@@ -32,6 +29,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -41,9 +39,12 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmoiron/sqlx v1.3.1 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/lib/pq v1.10.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
@@ -72,7 +73,6 @@ require (
 	gopkg.in/gorp.v1 v1.7.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.22.3 // indirect
 	k8s.io/apiextensions-apiserver v0.22.2 // indirect

--- a/pkg/helm/chartrepo.go
+++ b/pkg/helm/chartrepo.go
@@ -166,7 +166,7 @@ func TryToFindNewestReleaseByChart(chart *release.Release, repos []*Repo) *Chart
 	return newestRelease
 }
 
-// GetHelmReleasesVersion3 returns a collection of deployed helm version 3 charts in a cluster.
+// GetHelmReleasesVersion returns a collection of deployed helm version 3 charts in a cluster.
 func (h *Helm) GetHelmReleasesVersion(helmRepos []*Repo, helmReleases []*release.Release) []output.ReleaseOutput {
 	outputObjects := []output.ReleaseOutput{}
 

--- a/pkg/helm/chartrepo.go
+++ b/pkg/helm/chartrepo.go
@@ -1,0 +1,295 @@
+package helm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/fairwindsops/nova/pkg/output"
+	version "github.com/mcuadros/go-version"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/klog"
+)
+
+// Repo represents a Helm chart Repo
+type Repo struct {
+	URL    string
+	Charts *ChartReleases
+}
+
+// ChartReleases contains the chart releases of a helm repository
+type ChartReleases struct {
+	APIVersion string                    `yaml:"apiVersion"`
+	Entries    map[string][]ChartRelease `yaml:"entries"`
+}
+
+// ChartRelease is a single chart version in a helm repository
+type ChartRelease struct {
+	APIVersion  string             `yaml:"apiVersion,omitempty"`
+	AppVersion  string             `yaml:"appVersion"`
+	Created     time.Time          `yaml:"created"`
+	Description string             `yaml:"description"`
+	Digest      string             `yaml:"digest,omitempty"`
+	Maintainers []chart.Maintainer `yaml:"maintainers,omitempty"`
+	Name        string             `yaml:"name"`
+	Urls        []string           `yaml:"urls"`
+	Version     string             `yaml:"version"`
+	Home        string             `json:"home"`
+	Sources     []string           `json:"sources"`
+	Keywords    []string           `json:"keywords"`
+	Icon        string             `json:"icon"`
+	Deprecated  bool               `json:"deprecated"`
+}
+
+// NewRepos returns data about a helm chart repository, given its url
+func NewRepos(urls []string) []*Repo {
+	var repos []*Repo
+
+	var mutex = &sync.Mutex{}
+	var wg sync.WaitGroup
+	wg.Add(len(urls))
+
+	klog.V(5).Infof("loading %d chart repositories", len(urls))
+
+	for _, url := range urls {
+		klog.V(8).Infof("loading chart repository: %s", url)
+		go func(address string) {
+			defer wg.Done()
+			repo := &Repo{
+				URL:    address,
+				Charts: &ChartReleases{},
+			}
+			err := repo.loadReleases()
+			if err != nil {
+				klog.V(5).Infof("Could not load chart repo %s: %s", address, err)
+			} else {
+				mutex.Lock()
+				repos = append(repos, repo)
+				mutex.Unlock()
+			}
+		}(url)
+	}
+
+	wg.Wait()
+	return repos
+}
+
+func (r *Repo) loadReleases() error {
+	response, err := http.Get(fmt.Sprintf("%s/index.yaml", r.URL))
+	if err != nil {
+		return err
+	}
+
+	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(data, r.Charts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewestVersion returns the newest chart release for the provided release name
+func (r *Repo) NewestVersion(releaseName string) *ChartRelease {
+	for name, entries := range r.Charts.Entries {
+		if name == releaseName {
+			var newest ChartRelease
+			for _, release := range entries {
+				if IsValidRelease(release.Version) {
+					if newest.Version == "" {
+						newest = release
+					}
+
+					foundNewer := version.Compare(release.Version, newest.Version, ">")
+					if foundNewer {
+						newest = release
+					}
+				}
+			}
+			return &newest
+		}
+	}
+	return nil
+}
+
+// NewestChartVersion returns the newest chart release for the provided release name and version
+func (r *Repo) NewestChartVersion(currentChart *chart.Metadata) *ChartRelease {
+	for name, entries := range r.Charts.Entries {
+		if name == currentChart.Name {
+			var newest ChartRelease
+			repoHasCurrentVersion := false
+			for _, release := range entries {
+				if IsValidRelease(release.Version) {
+					if release.Version == currentChart.Version {
+						repoHasCurrentVersion = checkChartsSimilarity(currentChart, &release)
+					}
+
+					foundNewer := version.Compare(release.Version, newest.Version, ">")
+					if foundNewer {
+						newest = release
+					}
+				}
+			}
+			if repoHasCurrentVersion {
+				return &newest
+			}
+
+		}
+	}
+	return nil
+}
+
+// TryToFindNewestReleaseByChart will return the newest chart release given a collection of repos
+func TryToFindNewestReleaseByChart(chart *release.Release, repos []*Repo) *ChartRelease {
+	newestRelease := &ChartRelease{}
+	for _, repo := range repos {
+		newestInRepo := repo.NewestChartVersion(chart.Chart.Metadata)
+		if newestInRepo == nil {
+			continue
+		}
+		if newestRelease == nil {
+			newestRelease = newestInRepo
+		} else {
+			if version.Compare(newestInRepo.Version, newestRelease.Version, ">") {
+				newestRelease = newestInRepo
+			}
+		}
+	}
+	return newestRelease
+}
+
+// GetHelmReleasesVersion3 returns a collection of deployed helm version 3 charts in a cluster.
+func (h *Helm) GetHelmReleasesVersion(helmRepos []*Repo, helmReleases []*release.Release) []output.ReleaseOutput {
+	outputObjects := []output.ReleaseOutput{}
+
+	klog.V(5).Infof("Got %d installed releases in the cluster", len(helmReleases))
+	for _, chart := range helmReleases {
+		validRepos := IsRepoIncluded(chart.Chart.Metadata.Name, helmRepos)
+		newest := TryToFindNewestReleaseByChart(chart, validRepos)
+		if newest != nil {
+			rls := output.ReleaseOutput{
+				ReleaseName: chart.Name,
+				ChartName:   chart.Chart.Metadata.Name,
+				Namespace:   chart.Namespace,
+				Description: chart.Chart.Metadata.Description,
+				Icon:        chart.Chart.Metadata.Icon,
+				Home:        chart.Chart.Metadata.Home,
+				Installed: output.VersionInfo{
+					Version:    chart.Chart.Metadata.Version,
+					AppVersion: chart.Chart.Metadata.AppVersion,
+				},
+				Latest: output.VersionInfo{
+					Version:    newest.Version,
+					AppVersion: newest.AppVersion,
+				},
+				HelmVersion: "v3",
+				Deprecated:  chart.Chart.Metadata.Deprecated,
+			}
+			h.overrideDesiredVersion(&rls)
+			rls.IsOld = version.Compare(rls.Latest.Version, chart.Chart.Metadata.Version, ">")
+			outputObjects = append(outputObjects, rls)
+		}
+	}
+	return outputObjects
+}
+
+func (h *Helm) overrideDesiredVersion(rls *output.ReleaseOutput) {
+	for _, override := range h.DesiredVersions {
+		if rls.ChartName == override.Name {
+			klog.V(3).Infof("using override: %s=%s", rls.ChartName, override.Version)
+			rls.Latest = output.VersionInfo{
+				Version:    override.Version,
+				AppVersion: "",
+			}
+			rls.Overridden = true
+		}
+	}
+}
+
+func checkChartsSimilarity(currentChartMeta *chart.Metadata, chartFromRepo *ChartRelease) bool {
+
+	if currentChartMeta.Home != chartFromRepo.Home {
+		return false
+	}
+
+	if currentChartMeta.Description != chartFromRepo.Description {
+		return false
+	}
+
+	for _, source := range currentChartMeta.Sources {
+		if !containsString(chartFromRepo.Sources, source) {
+			return false
+		}
+	}
+
+	chartFromRepoMaintainers := map[string]bool{}
+	for _, m := range chartFromRepo.Maintainers {
+		chartFromRepoMaintainers[m.Email+";"+m.Name+";"+m.URL] = true
+	}
+	for _, m := range currentChartMeta.Maintainers {
+		if !chartFromRepoMaintainers[m.Email+";"+m.Name+";"+m.URL] {
+			return false
+		}
+	}
+	return true
+}
+
+// GetNewestReleaseByName will return the newest chart release given a collection of repos
+func GetNewestReleaseByName(name string, repos []*Repo) *ChartRelease {
+	newestRelease := &ChartRelease{}
+	for _, repo := range repos {
+		newestInRepo := repo.NewestVersion(name)
+		if newestRelease == nil {
+			newestRelease = newestInRepo
+		} else {
+			if version.Compare(newestInRepo.Version, newestRelease.Version, ">") {
+				newestRelease = newestInRepo
+			}
+		}
+	}
+	return newestRelease
+}
+
+// GetChartInfo returns info about a chart with the version specified
+func GetChartInfo(name string, version string, repos []*Repo) *ChartRelease {
+	for _, repo := range repos {
+		for key, chart := range repo.Charts.Entries {
+			if key == name {
+				for _, release := range chart {
+					if release.Version == version {
+						return &release
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// IsRepoIncluded check if the repo is included in the list of repos
+func IsRepoIncluded(chartName string, repos []*Repo) []*Repo {
+	found := []*Repo{}
+	for _, repo := range repos {
+		if contains(chartName, repo) {
+			found = append(found, repo)
+		}
+	}
+	return found
+}
+
+func contains(chartName string, repo *Repo) bool {
+	for name := range repo.Charts.Entries {
+		if name == chartName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/helm/chartrepo.go
+++ b/pkg/helm/chartrepo.go
@@ -149,7 +149,7 @@ func (r *Repo) NewestChartVersion(currentChart *chart.Metadata) *ChartRelease {
 
 // TryToFindNewestReleaseByChart will return the newest chart release given a collection of repos
 func TryToFindNewestReleaseByChart(chart *release.Release, repos []*Repo) *ChartRelease {
-	newestRelease := &ChartRelease{}
+	var newestRelease *ChartRelease
 	for _, repo := range repos {
 		newestInRepo := repo.NewestChartVersion(chart.Chart.Metadata)
 		if newestInRepo == nil {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -54,6 +54,7 @@ type VersionInfo struct {
 	AppVersion string `json:"appVersion"`
 }
 
+// NewOutputWithHelmReleases creates a new output object with the given helm releases pre-populated with the installed version
 func NewOutputWithHelmReleases(helmReleases []*release.Release) Output {
 	var output Output
 	for _, helmRelease := range helmReleases {


### PR DESCRIPTION
This PR fixes #71

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To add back the functionality that allows comparing against chart
repositories that are not represented in artifacthub (potentially
non-public repositories).

### What changes did you make?
- Added `--poll-artifacthub` to replace the legacy flag `poll-helm-hub`
- Added back the `--url` flag that allows providing custom helm
  repository URLs.

### What alternative solution should we consider, if any?
I'm unsure if it is reasonable in all situations to consider all charts
from a `--url` to take precedence over those found in artifacthub. I'm
interested in hearing if this is desirable or not.

### Example usage

Example usage of the `--url` parameters that still searches artifacthub as well. The dedupe function will prefer the charts found by the URLs.
```
❯ ./nova find --url "https://charts.fairwinds.com/stable" --url "https://charts.bitnami.com/bitnami" -v8
I0216 15:30:56.186245   41500 root.go:99] config not set, using flags only
I0216 15:30:56.186376   41500 root.go:183] Settings: map[context: desired-versions:map[] include-all:false output-file: poll-artifacthub:true url:[https://charts.fairwinds.com/stable https://charts.bitnami.com/bitnami] wide:false]
I0216 15:30:56.186396   41500 root.go:184] All Keys: [url poll-artifacthub context wide include-all output-file desired-versions]
I0216 15:30:56.408111   41500 artifacthub.go:200] found 52 packages matching 'redis'
I0216 15:30:56.412854   41500 artifacthub.go:200] found 2 packages matching 'vpa'
I0216 15:30:56.505814   41500 root.go:219] found 54 possible package matches
I0216 15:30:56.505986   41500 chartrepo.go:57] loading 2 chart repositories
I0216 15:30:56.505994   41500 chartrepo.go:60] loading chart repository: https://charts.fairwinds.com/stable
I0216 15:30:56.506004   41500 chartrepo.go:60] loading chart repository: https://charts.bitnami.com/bitnami
I0216 15:30:57.579143   41500 chartrepo.go:173] Got 2 installed releases in the cluster
I0216 15:30:57.581570   41500 output.go:114] deduplicating releases for output
I0216 15:30:57.581581   41500 output.go:121] found duplicate release: 'redis', chart: 'redis', namespace: 'redis'
I0216 15:30:57.581585   41500 output.go:121] found duplicate release: 'vpa', chart: 'vpa', namespace: 'vpa'
Release Name    Installed    Latest    Old     Deprecated
============    =========    ======    ===     ==========
redis           15.4.1       16.4.0    true    false
vpa             1.0.0        1.1.0     true    false
```

Example of the usage with `--poll-artifacthub` set to false so only those are used and artifacthub is not hit at all:
```
❯ ./nova find --poll-artifacthub=false --url "https://charts.fairwinds.com/stable" --url "https://charts.bitnami.com/bitnami" -v8
I0216 15:31:07.688000   41651 root.go:99] config not set, using flags only
I0216 15:31:07.688165   41651 root.go:183] Settings: map[context: desired-versions:map[] include-all:false output-file: poll-artifacthub:false url:[https://charts.fairwinds.com/stable https://charts.bitnami.com/bitnami] wide:false]
I0216 15:31:07.688189   41651 root.go:184] All Keys: [wide include-all output-file desired-versions url poll-artifacthub context]
I0216 15:31:07.728787   41651 chartrepo.go:57] loading 2 chart repositories
I0216 15:31:07.728806   41651 chartrepo.go:60] loading chart repository: https://charts.fairwinds.com/stable
I0216 15:31:07.728817   41651 chartrepo.go:60] loading chart repository: https://charts.bitnami.com/bitnami
I0216 15:31:08.886089   41651 chartrepo.go:173] Got 2 installed releases in the cluster
I0216 15:31:08.888538   41651 output.go:114] deduplicating releases for output
Release Name    Installed    Latest    Old     Deprecated
============    =========    ======    ===     ==========
redis           15.4.1       16.4.0    true    false
vpa             1.0.0        1.1.0     true    false
```