### PR TITLE
feat(ArgoCD): Added functionality to support pulling Helm charts from…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -233,7 +233,7 @@ var clusterCmd = &cobra.Command{
 		if len(viper.GetStringSlice("url")) > 0 {
 			repos := viper.GetStringSlice("url")
 			helmRepos := nova_helm.NewRepos(repos)
-			outputObjects := h.GetHelmReleasesVersion(helmRepos, releases)
+			outputObjects := h.GetHelmReleasesVersion(helmRepos, releases, viper.GetBool("argo-apps"))
 			out.HelmReleases = append(out.HelmReleases, outputObjects...)
 			if err != nil {
 				klog.Fatalf("Error getting helm releases from cluster: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,7 +189,7 @@ var clusterCmd = &cobra.Command{
 		klog.V(5).Infof("Settings: %v", viper.AllSettings())
 		klog.V(5).Infof("All Keys: %v", viper.AllKeys())
 
-		h := nova_helm.NewHelm(viper.GetString("context"))
+		h := nova_helm.NewHelm(viper.GetString("context"), viper.GetBool("argo-apps"))
 		ahClient, err := nova_helm.NewArtifactHubPackageClient(version)
 		if err != nil {
 			klog.Fatalf("error setting up artifact hub client: %s", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,12 @@ func init() {
 		klog.Fatalf("Failed to bind include-all flag: %v", err)
 	}
 
+	rootCmd.PersistentFlags().Bool("argo-apps", false, "When true, searches for helm charts deployed via argo application. If true, argocd CLI is expected to be properly configured in environment. Default is false.")
+	err = viper.BindPFlag("argo-apps", rootCmd.PersistentFlags().Lookup("argo-apps"))
+	if err != nil {
+		klog.Fatalf("Failed to bind argo-apps flag: %v", err)
+	}
+
 	klog.InitFlags(nil)
 	_ = flag.Set("alsologtostderr", "true")
 	_ = flag.Set("logtostderr", "true")
@@ -202,7 +208,7 @@ var clusterCmd = &cobra.Command{
 				})
 			}
 		}
-		releases, chartNames, err := h.GetReleaseOutput()
+		releases, chartNames, err := h.GetReleaseOutput(viper.GetBool("argo-apps"))
 		if err != nil {
 			klog.Fatalf("error getting helm releases: %s", err)
 		}

--- a/pkg/helm/cluster.go
+++ b/pkg/helm/cluster.go
@@ -60,9 +60,9 @@ type ArgoApp struct {
 }
 
 // NewHelm returns a basic helm struct with the version of helm requested
-func NewHelm(kubeContext string) *Helm {
+func NewHelm(kubeContext string, argo bool) *Helm {
 	return &Helm{
-		Kube: getConfigInstance(kubeContext),
+		Kube: getConfigInstance(kubeContext, argo),
 	}
 }
 
@@ -100,7 +100,7 @@ func (h *Helm) GetArgoReleases() ([]*release.Release, error) {
 
 	var applications []*release.Release
 	for _, i := range data {
-		if len(i.Spec.Source.Helm.ReleaseName) > 0 {
+		if len(i.Spec.Source.Helm.ReleaseName) > 0 && i.Spec.Destination.Namespace != "review" {
 			tempMetadata := chart.Metadata{
 				Name: i.Spec.Source.Chart,
 				Description: "n/a",

--- a/pkg/helm/kube.go
+++ b/pkg/helm/kube.go
@@ -17,6 +17,11 @@ package helm
 import (
 	"os"
 	"sync"
+	"fmt"
+
+	"path/filepath"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -33,20 +38,70 @@ type kube struct {
 var kubeClient *kube
 var once sync.Once
 
+// Modify kubeconfig raw context
+func SwitchContext(context string, kubeconfig string) (err error) {
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	configOverrides := &clientcmd.ConfigOverrides{}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	rawConfig, err := kubeConfig.RawConfig()
+	if err != nil {
+		return err
+	}
+	if rawConfig.Contexts[context] == nil {
+		return fmt.Errorf("context %s doesn't exists", context)
+	}
+	rawConfig.CurrentContext = context
+	err = clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), rawConfig, true)
+	if err != nil {
+		return fmt.Errorf("Error modifying config at %s", kubeconfig)
+	}
+	return
+}
+
+// Get raw config file path
+func getRawConfig(context string) (err error) {
+	var kubeconfig string
+
+	// Kubeconfig path, argo CLI implementation expects the default path
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	} else {
+		kubeconfig = "/root/.kube/config"
+	}
+
+	err = SwitchContext(context, kubeconfig)
+
+	if err != nil {
+		return err
+	}
+	return
+}
+
 // GetConfigInstance returns a Kubernetes interface based on the current configuration
-func getConfigInstance(context string) *kube {
+func getConfigInstance(context string, argo bool) *kube {
 	once.Do(func() {
 		if kubeClient == nil {
 			kubeClient = &kube{
-				Client: getKubeClient(context),
+				Client: getKubeClient(context, argo),
 			}
 		}
 	})
 	return kubeClient
 }
 
-func getKubeClient(context string) kubernetes.Interface {
+func getKubeClient(context string, argo bool) kubernetes.Interface {
 	var clientset *kubernetes.Clientset
+
+	if argo && len(context) > 0 {
+		err := getRawConfig(context)
+		if err != nil {
+			klog.Errorf("error modifying config with context %s: %v", context, err)
+			os.Exit(1)
+		}
+	}
 
 	kubeConf, err := config.GetConfigWithContext(context)
 	if err != nil {


### PR DESCRIPTION
… Argo Applications

This PR fixes #45

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add functionality to assess ArgoCD for helm charts deployed as Applications.

### What changes did you make?

- Added flag --argo-apps to instead search argo applications for helm charts
- Added functionality to pull helm chart, convert to expected helm release type, and return in place of helm releases. This is enabled by the flag
- Changed functionality to circumvent checking/verifying variables that are unknown to the Argo Applications. This is also enabled by the flag

### What alternative solution should we consider, if any?
- Currently uses basic exec command to run ArgoCD CLI. Could likely implement using their Go.

### Notes
- Cannot verify helm chart variables (such as maintainers, sources) on Argo applications as they do not include this information. May be some way to retrieve this info for security.
- Environment expects ArgoCD CLI to be both set up and "logged in" (using argocd login --core).
- Functions within cluster.go could be broken down better
