### PR TITLE
add flag --show-old to only charts not on the latest version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,6 +110,12 @@ func init() {
 		klog.Fatalf("Failed to bind show-errored-containers flag: %v", err)
 	}
 
+	rootCmd.PersistentFlags().Bool("show-old", false, "Only show charts that are not on the latest version")
+	err = viper.BindPFlag("show-old", rootCmd.PersistentFlags().Lookup("show-old"))
+	if err != nil {
+		klog.Fatalf("Failed to bind show-old flag: %v", err)
+	}
+
 	klog.InitFlags(nil)
 	_ = flag.Set("alsologtostderr", "true")
 	_ = flag.Set("logtostderr", "true")
@@ -298,7 +304,7 @@ var findCmd = &cobra.Command{
 				klog.Fatalf("error outputting to file: %s", err)
 			}
 		} else {
-			out.Print(viper.GetBool("wide"))
+			out.Print(viper.GetBool("wide"), viper.GetBool("show-old"))
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("show-old", false, "Only show charts that are not on the latest version")
 	err = viper.BindPFlag("show-old", rootCmd.PersistentFlags().Lookup("show-old"))
 	if err != nil {
-		klog.Fatalf("Failed to bind show-old flag: %v", err)
+		klog.Exitf("Failed to bind show-old flag: %v", err)
 	}
 
 	klog.InitFlags(nil)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,7 @@ Global Flags:
       --logtostderr                       log to standard error instead of files (default true)
       --output-file string                Path on local filesystem to write file output to
       --poll-artifacthub                  When true, polls artifacthub to match against helm releases in the cluster. If false, you must provide a url list via --url/-u. Default is true. (default true)
+      --show-old                          Only output charts that are not on the latest version
   -u, --url strings                       URL for a helm chart repo
   -v, --v Level                           number for the log level verbosity
       --wide                              Output chart name and namespace

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -107,7 +107,7 @@ func (output Output) ToFile(filename string) error {
 }
 
 // Print sends the output to STDOUT
-func (output Output) Print(wide bool) {
+func (output Output) Print(wide, showOld bool) {
 	if len(output.HelmReleases) == 0 {
 		fmt.Println("No releases found")
 		return
@@ -128,7 +128,7 @@ func (output Output) Print(wide bool) {
 	fmt.Fprintln(w, separator)
 
 	for _, release := range output.HelmReleases {
-		if !output.IncludeAll && release.Latest.Version == "" {
+		if (!output.IncludeAll && release.Latest.Version == "") || (showOld && !release.IsOld) {
 			continue
 		}
 		line := release.ReleaseName + "\t"


### PR DESCRIPTION
This PR fixes #110 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add a flag `--show-old` to only output charts that are not on the latest version. 

### What changes did you make?
Added a flag `--show-old` which hides the output if chart is not old

### What alternative solution should we consider, if any?
none
