### PR TITLE
Make nova buildable with nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules
 /dist
 
 /nova.yaml
+
+/result
+/.direnv

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,3 +30,8 @@ brew install fairwindsops/tap/nova
 ```
 go get github.com/fairwindsops/nova
 ```
+
+### nix (on linux or macOS)
+```
+nix profile install github:FairwindsOps/Nova
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1664178928,
+        "narHash": "sha256-+WVCZH/3Ifef4Da9N1tkGnmfX0QwtkJQz013QuImu10=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b542cc75fa03a3a29350d4c3b69739e946268a93",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Find outdated or deprecated Helm charts running in your cluster";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixos-22.05";
+
+  outputs = { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          nova = pkgs.buildGoModule {
+            pname = "nova";
+            inherit version;
+            # In 'nix develop', we don't need a copy of the source tree
+            # in the Nix store.
+            src = ./.;
+
+            # This hash locks the dependencies of this package. It is
+            # necessary because of how Go requires network access to resolve
+            # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
+            # details. Normally one can build with a fake sha256 and rely on native Go
+            # mechanisms to tell you what the hash should be or determine what
+            # it should be "out-of-band" with other tooling (eg. gomod2nix).
+            # To begin with it is recommended to set this, but one must
+            # remeber to bump this hash when your dependencies change.
+            #vendorSha256 = pkgs.lib.fakeSha256;
+
+            vendorSha256 = "sha256-ANbFVyLCJe0kseU9zdJflvfDTdnKnouT2T/MkwY3lXc=";
+          };
+        });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage = forAllSystems (system: self.packages.${system}.nova);
+    };
+}


### PR DESCRIPTION
This makes Nova buildable with nix (allowing easier import into nix-managed systems and docker containers).