### PR TITLE
Use new ArtifactHub cached API

### DIFF
--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -92,6 +92,7 @@ type ArtifactHubRepository struct {
 	URL               string `json:"url"`
 	Name              string `json:"name"`
 	VerifiedPublisher bool   `json:"verified_publisher"`
+	Official          bool   `json:"official"`
 }
 
 // ArtifactHubHelmPackage represents a helm package (chart) as provided by the ArtifactHub API.
@@ -100,6 +101,7 @@ type ArtifactHubHelmPackage struct {
 	DisplayName       string                `json:"display_name"`
 	Description       string                `json:"description"`
 	AppVersion        string                `json:"app_version"`
+	Official          bool                  `json:"official"`
 	Deprecated        bool                  `json:"deprecated"`
 	Repository        ArtifactHubRepository `json:"repository"`
 	Version           string                `json:"version"`

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -98,7 +98,6 @@ type ArtifactHubRepository struct {
 type ArtifactHubHelmPackage struct {
 	Name              string                `json:"name"`
 	DisplayName       string                `json:"display_name"`
-	LogoImageID       string                `json:"logo_image_id"`
 	Description       string                `json:"description"`
 	AppVersion        string                `json:"app_version"`
 	Deprecated        bool                  `json:"deprecated"`

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -103,38 +103,26 @@ type ArtifactHubRepository struct {
 
 // ArtifactHubHelmPackage represents a helm package (chart) as provided by the ArtifactHub API.
 type ArtifactHubHelmPackage struct {
-	PackageID                      string                           `json:"package_id"`
 	Name                           string                           `json:"name"`
-	NormalizedName                 string                           `json:"normalized_name"`
 	DisplayName                    string                           `json:"display_name"`
 	LogoImageID                    string                           `json:"logo_image_id"`
-	Stars                          int                              `json:"stars"`
 	Description                    string                           `json:"description"`
 	Version                        string                           `json:"version"`
 	AppVersion                     string                           `json:"app_version"`
 	Deprecated                     bool                             `json:"deprecated"`
 	Signed                         bool                             `json:"signed"`
 	Official                       bool                             `json:"official"`
-	ProductionOrganizationsCount   int                              `json:"production_organizations_count"`
-	Ts                             int                              `json:"ts"`
 	Repository                     ArtifactHubRepository            `json:"repository"`
-	SecurityReportSummary          ArtifactHubSecurityReportSummary `json:"security_report_summary"`
-	AllContainersImagesWhitelisted bool                             `json:"all_containers_images_whitelisted"`
 	LatestVersion                  string                           `json:"latest_version"`
 	HomeURL                        string                           `json:"home_url"`
 	AvailableVersions              []AvailableVersion               `json:"available_versions"`
 	Maintainers                    []Maintainer                     `json:"maintainers"`
-	PreRelease                     bool                             `json:"prerelease"`
-	Data                           PackageData                      `json:"data"`
 	Links                          []Link                           `json:"links"`
 }
 
 // AvailableVersion is a sub struct of ArtifactHubHelmPackage and provides a version that is available for a given helm chart.
 type AvailableVersion struct {
 	Version                 string `json:"version"`
-	ContainsSecurityUpdates bool   `json:"contains_security_updates"`
-	PreRelease              bool   `json:"prerelease"`
-	Ts                      int    `json:"ts"`
 }
 
 // Maintainer is a child struct of ArtifactHubHelmPackage and provides information about maintainers of a helm chart.

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -90,15 +90,8 @@ type ArtifactHubSecurityReportSummary struct {
 // ArtifactHubRepository is a child struct of ArtifactHubPackageSearch represents a helm chart repository as provided by the ArtifactHub API.
 type ArtifactHubRepository struct {
 	URL                     string `json:"url"`
-	Kind                    int    `json:"kind"`
 	Name                    string `json:"name"`
-	Official                bool   `json:"official"`
-	DisplayName             string `json:"display_name"`
-	RepositoryID            string `json:"repository_id"`
-	ScannerDisabled         bool   `json:"scanner_disabled"`
-	OrganizationName        string `json:"organization_name"`
 	VerifiedPublisher       bool   `json:"verified_publisher"`
-	OrganizationDisplayName string `json:"organization_display_name"`
 }
 
 // ArtifactHubHelmPackage represents a helm package (chart) as provided by the ArtifactHub API.
@@ -107,13 +100,10 @@ type ArtifactHubHelmPackage struct {
 	DisplayName                    string                           `json:"display_name"`
 	LogoImageID                    string                           `json:"logo_image_id"`
 	Description                    string                           `json:"description"`
-	Version                        string                           `json:"version"`
 	AppVersion                     string                           `json:"app_version"`
 	Deprecated                     bool                             `json:"deprecated"`
-	Signed                         bool                             `json:"signed"`
-	Official                       bool                             `json:"official"`
 	Repository                     ArtifactHubRepository            `json:"repository"`
-	LatestVersion                  string                           `json:"latest_version"`
+	Version                  string                                  `json:"version"`
 	HomeURL                        string                           `json:"home_url"`
 	AvailableVersions              []AvailableVersion               `json:"available_versions"`
 	Maintainers                    []Maintainer                     `json:"maintainers"`

--- a/pkg/helm/artifacthub.go
+++ b/pkg/helm/artifacthub.go
@@ -89,30 +89,30 @@ type ArtifactHubSecurityReportSummary struct {
 
 // ArtifactHubRepository is a child struct of ArtifactHubPackageSearch represents a helm chart repository as provided by the ArtifactHub API.
 type ArtifactHubRepository struct {
-	URL                     string `json:"url"`
-	Name                    string `json:"name"`
-	VerifiedPublisher       bool   `json:"verified_publisher"`
+	URL               string `json:"url"`
+	Name              string `json:"name"`
+	VerifiedPublisher bool   `json:"verified_publisher"`
 }
 
 // ArtifactHubHelmPackage represents a helm package (chart) as provided by the ArtifactHub API.
 type ArtifactHubHelmPackage struct {
-	Name                           string                           `json:"name"`
-	DisplayName                    string                           `json:"display_name"`
-	LogoImageID                    string                           `json:"logo_image_id"`
-	Description                    string                           `json:"description"`
-	AppVersion                     string                           `json:"app_version"`
-	Deprecated                     bool                             `json:"deprecated"`
-	Repository                     ArtifactHubRepository            `json:"repository"`
-	Version                  string                                  `json:"version"`
-	HomeURL                        string                           `json:"home_url"`
-	AvailableVersions              []AvailableVersion               `json:"available_versions"`
-	Maintainers                    []Maintainer                     `json:"maintainers"`
-	Links                          []Link                           `json:"links"`
+	Name              string                `json:"name"`
+	DisplayName       string                `json:"display_name"`
+	LogoImageID       string                `json:"logo_image_id"`
+	Description       string                `json:"description"`
+	AppVersion        string                `json:"app_version"`
+	Deprecated        bool                  `json:"deprecated"`
+	Repository        ArtifactHubRepository `json:"repository"`
+	Version           string                `json:"version"`
+	HomeURL           string                `json:"home_url"`
+	AvailableVersions []AvailableVersion    `json:"available_versions"`
+	Maintainers       []Maintainer          `json:"maintainers"`
+	Links             []Link                `json:"links"`
 }
 
 // AvailableVersion is a sub struct of ArtifactHubHelmPackage and provides a version that is available for a given helm chart.
 type AvailableVersion struct {
-	Version                 string `json:"version"`
+	Version string `json:"version"`
 }
 
 // Maintainer is a child struct of ArtifactHubHelmPackage and provides information about maintainers of a helm chart.

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -15,12 +15,12 @@
 package helm
 
 import (
-	"os"
-	"io/ioutil"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 
 	"k8s.io/klog/v2"
 )
@@ -32,6 +32,7 @@ const (
 )
 
 var cacheFile = ""
+
 func init() {
 	if os.Getenv("ARTIFACT_HUB_CACHE_FILE") != "" {
 		cacheFile = os.Getenv("ARTIFACT_HUB_CACHE_FILE")

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -106,17 +106,14 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 				VerifiedPublisher: cachedPackage.Repository.Verified,
 				Official:          cachedPackage.Repository.Official,
 			},
-			// Version: cachedPackage.Version (what does this represent?)
-			// Deprecated: cachedPackage.Deprecated,
-			// LatestVersion: cachedPackage.LatestVersion,
+			Deprecated: cachedPackage.Deprecated,
+			LatestVersion: cachedPackage.LatestVersion,
 			AvailableVersions: []AvailableVersion{},
 		}
 		for _, version := range cachedPackage.Versions {
-			/*
-				if version == cachedPackage.LatestVersion {
-					packages[idx].AppVersion = version.AppVersion
-				}
-			*/
+			if version == cachedPackage.LatestVersion {
+				packages[idx].AppVersion = version.AppVersion
+			}
 			packages[idx].AvailableVersions = append(packages[idx].AvailableVersions, AvailableVersion{
 				Version: version.Version,
 			})

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -98,7 +98,7 @@ func NewArtifactHubCachedPackageClient(version string) (*ArtifactHubCachedPackag
 func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, error) {
 	list := ArtifactHubCachedPackagesList{}
 	if cacheFile == "" {
-		resp, err := ac.get("", url.Values{})
+		resp, err := ac.get()
 		if err != nil {
 			return nil, err
 		}
@@ -147,25 +147,15 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 	return packages, nil
 }
 
-// get is the basic getter for the artifacthub package client
-// The path argument should be formatted like so: "api/v1/packages/search", any unauthenticated paths
-// will work and are documented here: https://artifacthub.io/docs/api/#/
-// urlValues are the search parameters for the query if necessary.
-// offset is to be used for pagination. The first page would be offset 0.
-func (ac *ArtifactHubCachedPackageClient) get(path string, urlValues url.Values) (*http.Response, error) {
+// get is the basic getter for the artifacthub cached package client
+func (ac *ArtifactHubCachedPackageClient) get() (*http.Response, error) {
 	requestURL := *ac.URL
-	requestURL.Path = path
 	urlString := requestURL.String()
 	r, err := http.NewRequest("GET", urlString, nil)
 	if err != nil {
 		return nil, err
 	}
 	q := r.URL.Query()
-	for k, v := range urlValues {
-		for _, vv := range v {
-			q.Add(k, vv)
-		}
-	}
 	r.URL.RawQuery = q.Encode()
 	r.Header.Add("accept", "application/json")
 	r.Header.Set("User-Agent", ac.UserAgent)

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -42,13 +42,13 @@ type ArtifactHubCachedPackagesList []ArtifactHubCachedPackage
 
 // ArtifactHubCachedPackage represents a single entry in the API output. It's a single chart registered in AH
 type ArtifactHubCachedPackage struct {
-	Name        string                       `json:"name"`
-	Description string                       `json:"description"`
-	HomeURL     string                       `json:"home_url"`
-	Repository  ArtifactHubCachedRepository  `json:"repository"`
-	Versions     []ArtifactHubCachedVersionInfo `json:"versions"`
-	Links       []Link                       `json:"links"`
-	Maintainers []Maintainer                 `json:"maintainers"`
+	Name        string                         `json:"name"`
+	Description string                         `json:"description"`
+	HomeURL     string                         `json:"home_url"`
+	Repository  ArtifactHubCachedRepository    `json:"repository"`
+	Versions    []ArtifactHubCachedVersionInfo `json:"versions"`
+	Links       []Link                         `json:"links"`
+	Maintainers []Maintainer                   `json:"maintainers"`
 }
 
 // ArtifactHubCachedRepository is a sub-struct of the Package struct, and represents the repository containing the package.
@@ -61,7 +61,7 @@ type ArtifactHubCachedRepository struct {
 
 // ArtifactHubCachedVersionInfo represents the chart and application version of a package
 type ArtifactHubCachedVersionInfo struct {
-	Version string `json:"pkg"`
+	Version    string `json:"pkg"`
 	AppVersion string `json:"app"`
 }
 
@@ -92,15 +92,15 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 	packages := make([]ArtifactHubHelmPackage, len(list))
 	for idx, cachedPackage := range list {
 		packages[idx] = ArtifactHubHelmPackage{
-			Name: cachedPackage.Name,
+			Name:        cachedPackage.Name,
 			Description: cachedPackage.Description,
 			Maintainers: cachedPackage.Maintainers,
-			HomeURL: cachedPackage.HomeURL,
-			Links: cachedPackage.Links,
+			HomeURL:     cachedPackage.HomeURL,
+			Links:       cachedPackage.Links,
 			Repository: ArtifactHubRepository{
-				Name: cachedPackage.Repository.Name,
+				Name:              cachedPackage.Repository.Name,
 				VerifiedPublisher: cachedPackage.Repository.Verified,
-				URL: cachedPackage.Repository.URL,
+				URL:               cachedPackage.Repository.URL,
 			},
 			// LogoImageID: cachedPackage.LogoImageID,
 			// Version: cachedPackage.Version (what does this represent?)
@@ -110,9 +110,9 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 		}
 		for _, version := range cachedPackage.Versions {
 			/*
-			if version == cachedPackage.LatestVersion {
-				packages[idx].AppVersion = version.AppVersion
-			}
+				if version == cachedPackage.LatestVersion {
+					packages[idx].AppVersion = version.AppVersion
+				}
 			*/
 			packages[idx].AvailableVersions = append(packages[idx].AvailableVersions, AvailableVersion{
 				Version: version.Version,

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -31,6 +31,13 @@ const (
 	artifactHubCachedHelmKind        = "0"
 )
 
+var cacheFile = ""
+func init() {
+	if os.Getenv("ARTIFACT_HUB_CACHE_FILE") != "" {
+		cacheFile = os.Getenv("ARTIFACT_HUB_CACHE_FILE")
+	}
+}
+
 // ArtifactHubCachedPackageClient provides the various pieces to interact with the ArtifactHubCached API.
 type ArtifactHubCachedPackageClient struct {
 	APIRoot   string
@@ -90,7 +97,7 @@ func NewArtifactHubCachedPackageClient(version string) (*ArtifactHubCachedPackag
 // List returns all packages from ArtifactHub
 func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, error) {
 	list := ArtifactHubCachedPackagesList{}
-	if os.Getenv("ARTIFACT_HUB_CACHE_FILE") == "" {
+	if cacheFile == "" {
 		resp, err := ac.get("", url.Values{})
 		if err != nil {
 			return nil, err
@@ -100,7 +107,7 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 			return nil, err
 		}
 	} else {
-		cache, err := ioutil.ReadFile(os.Getenv("ARTIFACT_HUB_CACHE_FILE"))
+		cache, err := ioutil.ReadFile(cacheFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -160,23 +160,13 @@ func (ac *ArtifactHubCachedPackageClient) get() (*http.Response, error) {
 	r.URL.RawQuery = q.Encode()
 	r.Header.Add("accept", "application/json")
 	r.Header.Set("User-Agent", ac.UserAgent)
-	var response *http.Response
-	for attempt := 1; attempt <= 5; attempt++ {
-		resp, innerErr := ac.Client.Do(r)
-		if innerErr != nil {
-			response = nil
-			err = innerErr
-			klog.V(3).Infof("attempt %d failed to GET %s: %v", attempt, urlString, err)
-			continue
-		}
-		if resp.StatusCode != http.StatusOK {
-			response = resp
-			klog.V(3).Infof("attempt %d failed to GET %s with status code: %v", attempt, urlString, resp.StatusCode)
-			err = fmt.Errorf("error code: %d", resp.StatusCode)
-			continue
-		}
-		response = resp
-		break
+	resp, err := ac.Client.Do(r)
+	if err != nil {
+		return nil, err
 	}
-	return response, err
+	if resp.StatusCode != http.StatusOK {
+		klog.V(3).Infof("failed to GET %s with status code: %v", urlString, resp.StatusCode)
+		err = fmt.Errorf("error code: %d", resp.StatusCode)
+	}
+	return resp, err
 }

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -37,8 +37,10 @@ type ArtifactHubCachedPackageClient struct {
 	UserAgent string
 }
 
+// ArtifactHubCachedPackagesList contains the output from the AH cached API
 type ArtifactHubCachedPackagesList []ArtifactHubCachedPackage
 
+// ArtifactHubCachedPackage represents a single entry in the API output. It's a single chart registered in AH
 type ArtifactHubCachedPackage struct {
 	Name        string                       `json:"name"`
 	Description string                       `json:"description"`
@@ -49,6 +51,7 @@ type ArtifactHubCachedPackage struct {
 	Maintainers []Maintainer                 `json:"maintainers"`
 }
 
+// ArtifactHubCachedRepository is a sub-struct of the Package struct, and represents the repository containing the package.
 type ArtifactHubCachedRepository struct {
 	Name     string `json:"name"`
 	URL      string `json:"url"`
@@ -56,6 +59,7 @@ type ArtifactHubCachedRepository struct {
 	Verified bool   `json:"verified"`
 }
 
+// ArtifactHubCachedVersionInfo represents the chart and application version of a package
 type ArtifactHubCachedVersionInfo struct {
 	Version string `json:"pkg"`
 	AppVersion string `json:"app"`
@@ -77,6 +81,7 @@ func NewArtifactHubCachedPackageClient(version string) (*ArtifactHubCachedPackag
 	}, nil
 }
 
+// List returns all packages from ArtifactHub
 func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, error) {
 	resp, err := ac.get("", url.Values{})
 	if err != nil {

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -44,7 +44,7 @@ type ArtifactHubCachedPackagesList []ArtifactHubCachedPackage
 type ArtifactHubCachedPackage struct {
 	Name        string                         `json:"name"`
 	Description string                         `json:"description"`
-	HomeURL     string                         `json:"home_url"`
+	HomeURL     string                         `json:"home"`
 	Repository  ArtifactHubCachedRepository    `json:"repository"`
 	Official    bool                           `json:"official"`
 	Versions    []ArtifactHubCachedVersionInfo `json:"versions"`

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -42,14 +42,16 @@ type ArtifactHubCachedPackagesList []ArtifactHubCachedPackage
 
 // ArtifactHubCachedPackage represents a single entry in the API output. It's a single chart registered in AH
 type ArtifactHubCachedPackage struct {
-	Name        string                         `json:"name"`
-	Description string                         `json:"description"`
-	HomeURL     string                         `json:"home"`
-	Repository  ArtifactHubCachedRepository    `json:"repository"`
-	Official    bool                           `json:"official"`
-	Versions    []ArtifactHubCachedVersionInfo `json:"versions"`
-	Links       []Link                         `json:"links"`
-	Maintainers []Maintainer                   `json:"maintainers"`
+	Name          string                         `json:"name"`
+	Description   string                         `json:"description"`
+	HomeURL       string                         `json:"home"`
+	Repository    ArtifactHubCachedRepository    `json:"repository"`
+	Official      bool                           `json:"official"`
+	LatestVersion string                         `json:"latest_version"`
+	Versions      []ArtifactHubCachedVersionInfo `json:"versions"`
+	Links         []Link                         `json:"links"`
+	Maintainers   []Maintainer                   `json:"maintainers"`
+	Deprecated    bool                           `json:"deprecated"`
 }
 
 // ArtifactHubCachedRepository is a sub-struct of the Package struct, and represents the repository containing the package.
@@ -106,13 +108,13 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 				VerifiedPublisher: cachedPackage.Repository.Verified,
 				Official:          cachedPackage.Repository.Official,
 			},
-			Deprecated: cachedPackage.Deprecated,
-			LatestVersion: cachedPackage.LatestVersion,
+			Version:           cachedPackage.LatestVersion,
 			AvailableVersions: []AvailableVersion{},
 		}
 		for _, version := range cachedPackage.Versions {
-			if version == cachedPackage.LatestVersion {
+			if version.Version == cachedPackage.LatestVersion {
 				packages[idx].AppVersion = version.AppVersion
+				packages[idx].Deprecated = version.Deprecated
 			}
 			packages[idx].AvailableVersions = append(packages[idx].AvailableVersions, AvailableVersion{
 				Version: version.Version,

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -1,0 +1,128 @@
+// Copyright 2020 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	artifactHubCachedAPIRoot         = "https://artifacthub.io/api/v1/nova"
+	maxArtifactHubCachedRequestLimit = 60
+	artifactHubCachedHelmKind        = "0"
+)
+
+// ArtifactHubCachedPackageClient provides the various pieces to interact with the ArtifactHubCached API.
+type ArtifactHubCachedPackageClient struct {
+	APIRoot   string
+	URL       *url.URL
+	Client    *http.Client
+	UserAgent string
+}
+
+type ArtifactHubCachedPackagesList []ArtifactHubCachedPackage
+
+type ArtifactHubCachedPackage struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Repository  ArtifactHubCachedRepository  `json:"repository"`
+	Version     ArtifactHubCachedVersionInfo `json:"version"`
+}
+
+type ArtifactHubCachedRepository struct {
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	Official bool   `json:"official"`
+	Verified bool   `json:"verified"`
+}
+
+type ArtifactHubCachedVersionInfo struct {
+	Latest string   `json:"latest"`
+	All    []string `json:"all"`
+}
+
+// NewArtifactHubCachedPackageClient returns a new client for the unauthenticated paths of the ArtifactHubCached API.
+func NewArtifactHubCachedPackageClient(version string) (*ArtifactHubCachedPackageClient, error) {
+	apiRoot := artifactHubCachedAPIRoot
+	u, err := url.ParseRequestURI(apiRoot)
+	if err != nil {
+		return nil, err
+	}
+	client := new(http.Client)
+	return &ArtifactHubCachedPackageClient{
+		APIRoot:   apiRoot,
+		URL:       u,
+		Client:    client,
+		UserAgent: fmt.Sprintf("Fairwinds-Nova/%s ", version),
+	}, nil
+}
+
+func (ac *ArtifactHubCachedPackageClient) List(path string, urlValues url.Values) (*ArtifactHubCachedPackagesList, error) {
+	resp, err := ac.get("", url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	list := ArtifactHubCachedPackagesList{}
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	return &list, err
+}
+
+// get is the basic getter for the artifacthub package client
+// The path argument should be formatted like so: "api/v1/packages/search", any unauthenticated paths
+// will work and are documented here: https://artifacthub.io/docs/api/#/
+// urlValues are the search parameters for the query if necessary.
+// offset is to be used for pagination. The first page would be offset 0.
+func (ac *ArtifactHubCachedPackageClient) get(path string, urlValues url.Values) (*http.Response, error) {
+	requestURL := *ac.URL
+	requestURL.Path = path
+	urlString := requestURL.String()
+	r, err := http.NewRequest("GET", urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := r.URL.Query()
+	for k, v := range urlValues {
+		for _, vv := range v {
+			q.Add(k, vv)
+		}
+	}
+	r.URL.RawQuery = q.Encode()
+	r.Header.Add("accept", "application/json")
+	r.Header.Set("User-Agent", ac.UserAgent)
+	var response *http.Response
+	for attempt := 1; attempt <= 5; attempt++ {
+		resp, innerErr := ac.Client.Do(r)
+		if innerErr != nil {
+			response = nil
+			err = innerErr
+			klog.V(3).Infof("attempt %d failed to GET %s: %v", attempt, urlString, err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			response = resp
+			klog.V(3).Infof("attempt %d failed to GET %s with status code: %v", attempt, urlString, resp.StatusCode)
+			err = fmt.Errorf("error code: %d", resp.StatusCode)
+			continue
+		}
+		response = resp
+		break
+	}
+	return response, err
+}

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -46,6 +46,7 @@ type ArtifactHubCachedPackage struct {
 	Description string                         `json:"description"`
 	HomeURL     string                         `json:"home_url"`
 	Repository  ArtifactHubCachedRepository    `json:"repository"`
+	Official    bool                           `json:"official"`
 	Versions    []ArtifactHubCachedVersionInfo `json:"versions"`
 	Links       []Link                         `json:"links"`
 	Maintainers []Maintainer                   `json:"maintainers"`
@@ -98,10 +99,12 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 			Maintainers: cachedPackage.Maintainers,
 			HomeURL:     cachedPackage.HomeURL,
 			Links:       cachedPackage.Links,
+			Official:    cachedPackage.Official,
 			Repository: ArtifactHubRepository{
 				Name:              cachedPackage.Repository.Name,
 				URL:               cachedPackage.Repository.URL,
 				VerifiedPublisher: cachedPackage.Repository.Verified,
+				Official:          cachedPackage.Repository.Official,
 			},
 			// Version: cachedPackage.Version (what does this represent?)
 			// Deprecated: cachedPackage.Deprecated,

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -63,6 +63,7 @@ type ArtifactHubCachedRepository struct {
 type ArtifactHubCachedVersionInfo struct {
 	Version    string `json:"pkg"`
 	AppVersion string `json:"app"`
+	Deprecated bool   `json:"deprecated"`
 }
 
 // NewArtifactHubCachedPackageClient returns a new client for the unauthenticated paths of the ArtifactHubCached API.
@@ -99,10 +100,9 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 			Links:       cachedPackage.Links,
 			Repository: ArtifactHubRepository{
 				Name:              cachedPackage.Repository.Name,
-				VerifiedPublisher: cachedPackage.Repository.Verified,
 				URL:               cachedPackage.Repository.URL,
+				VerifiedPublisher: cachedPackage.Repository.Verified,
 			},
-			// LogoImageID: cachedPackage.LogoImageID,
 			// Version: cachedPackage.Version (what does this represent?)
 			// Deprecated: cachedPackage.Deprecated,
 			// LatestVersion: cachedPackage.LatestVersion,

--- a/pkg/helm/artifacthub_cached_sample.json
+++ b/pkg/helm/artifacthub_cached_sample.json
@@ -1,0 +1,22 @@
+[{
+    "name": "vault-secrets-operator",
+    "description": "Official Vault Secrets Operator Chart",
+    "links": [
+        {
+            "url": "https://github.com/hashicorp/vault-secrets-operator",
+            "name": "source"
+        }
+    ],
+    "repository": {
+        "name": "hashicorp",
+        "url": "https://helm.releases.hashicorp.com",
+        "official": true,
+        "verified": true
+    },
+    "version": {
+        "latest": "0.1.0-beta",
+        "all": [
+            "0.1.0-beta"
+        ]
+    }
+}]

--- a/pkg/helm/artifacthub_cached_sample.json
+++ b/pkg/helm/artifacthub_cached_sample.json
@@ -1,22 +1,54 @@
 [{
-    "name": "vault-secrets-operator",
-    "description": "Official Vault Secrets Operator Chart",
+    "name": "secrets-store-csi-driver-provider-gcp",
+    "description": "A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver",
     "links": [
         {
-            "url": "https://github.com/hashicorp/vault-secrets-operator",
+            "url": "https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp",
             "name": "source"
+        },
+        {
+            "url": "https://github.com/kubernetes-sigs/secrets-store-csi-driver",
+            "name": "secrets-store-csi-driver"
+        },
+        {
+            "url": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp",
+            "name": "secrets-store-csi-driver-provider-gcp"
+        },
+        {
+            "url": "https://portefaix.xyz",
+            "name": "Portefaix"
+        }
+    ],
+    "home_url": "https://charts.portefaix.xyz",
+    "maintainers": [
+        {
+            "name": "nlamirault"
         }
     ],
     "repository": {
-        "name": "hashicorp",
-        "url": "https://helm.releases.hashicorp.com",
-        "official": true,
-        "verified": true
+        "name": "portefaix-hub",
+        "url": "https://charts.portefaix.xyz/"
     },
-    "version": {
-        "latest": "0.1.0-beta",
-        "all": [
-            "0.1.0-beta"
-        ]
-    }
+    "versions": [
+        {
+            "pkg": "0.1.0",
+            "app": "1.3.5"
+        },
+        {
+            "pkg": "0.2.0",
+            "app": "1.3.5"
+        },
+        {
+            "pkg": "0.3.0",
+            "app": "1.3.5"
+        },
+        {
+            "pkg": "0.4.0",
+            "app": "1.0.0"
+        },
+        {
+            "pkg": "0.5.0",
+            "app": "1.0.0"
+        }
+    ]
 }]

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -34,7 +34,7 @@ func Test_ingestSample(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(resp))
-	assert.Equal(t, "secrets-store-csi-driver-provider-gc", resp[0].Name)
+	assert.Equal(t, "secrets-store-csi-driver-provider-gcp", resp[0].Name)
 	assert.Equal(t, "A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver", resp[0].Description)
 	assert.Equal(t, 4, len(resp[0].Links))
 	assert.Equal(t, "https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp", resp[0].Links[0].URL)

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -34,5 +34,5 @@ func Test_ingestSample(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(resp))
-	assert.Equal(t, "vault-secrets-operator", resp[0].Name)
+	assert.Equal(t, "secrets-store-csi-driver-provider-gc", resp[0].Name)
 }

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"io/ioutil"
+	"testing"
+	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleFile = "artifacthub_cached_sample.json"
+
+func Test_ingestSample(t *testing.T) {
+	sample, err := ioutil.ReadFile(sampleFile)
+	if err != nil {
+		panic(err)
+	}
+	resp := ArtifactHubCachedPackagesList{}
+	err = json.Unmarshal(sample, &resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(resp))
+	assert.Equal(t, "vault-secrets-operator", resp[0].Name)
+}

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -15,8 +15,6 @@
 package helm
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,18 +23,29 @@ import (
 const sampleFile = "artifacthub_cached_sample.json"
 
 func Test_ingestSample(t *testing.T) {
-	sample, err := ioutil.ReadFile(sampleFile)
-	if err != nil {
-		panic(err)
-	}
-	resp := ArtifactHubCachedPackagesList{}
-	err = json.Unmarshal(sample, &resp)
+	cacheFile = sampleFile
+	client, err := NewArtifactHubCachedPackageClient("")
+	assert.NoError(t, err)
+	resp, err := client.List()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(resp))
-	assert.Equal(t, "secrets-store-csi-driver-provider-gcp", resp[0].Name)
-	assert.Equal(t, "A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver", resp[0].Description)
-	assert.Equal(t, 4, len(resp[0].Links))
-	assert.Equal(t, "https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp", resp[0].Links[0].URL)
-	assert.Equal(t, "source", resp[0].Links[0].Name)
+	assert.Equal(t, 11233, len(resp))
+	toCheck := resp[1]
+	assert.Equal(t, "open5gs-webui", toCheck.Name)
+	assert.Equal(t, "Helm chart to deploy Open5gs WebUI service on Kubernetes. ", toCheck.Description)
+
+	assert.Equal(t, 1, len(toCheck.Links))
+	assert.Equal(t, "http://open5gs.org", toCheck.Links[0].URL)
+	assert.Equal(t, "source", toCheck.Links[0].Name)
+
+	assert.Equal(t, 2, len(toCheck.Maintainers))
+	assert.Equal(t, "cgiraldo", toCheck.Maintainers[0].Name)
+
+	assert.Equal(t, "gradiant-openverso", toCheck.Repository.Name)
+	assert.Equal(t, "https://gradiant.github.io/openverso-charts/", toCheck.Repository.URL)
+
+	assert.Equal(t, "2.0.3", toCheck.Version)
+	assert.Equal(t, "2.4.11", toCheck.AppVersion)
+	assert.Equal(t, 4, len(toCheck.AvailableVersions))
+	assert.Equal(t, "2.0.0", toCheck.AvailableVersions[0].Version)
 }

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -15,9 +15,9 @@
 package helm
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
-	"encoding/json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/helm/artifacthub_cached_test.go
+++ b/pkg/helm/artifacthub_cached_test.go
@@ -35,4 +35,8 @@ func Test_ingestSample(t *testing.T) {
 
 	assert.Equal(t, 1, len(resp))
 	assert.Equal(t, "secrets-store-csi-driver-provider-gc", resp[0].Name)
+	assert.Equal(t, "A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver", resp[0].Description)
+	assert.Equal(t, 4, len(resp[0].Links))
+	assert.Equal(t, "https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp", resp[0].Links[0].URL)
+	assert.Equal(t, "source", resp[0].Links[0].Name)
 }

--- a/pkg/helm/chartrepo.go
+++ b/pkg/helm/chartrepo.go
@@ -246,10 +246,10 @@ func checkChartsSimilarity(currentChartMeta *chart.Metadata, chartFromRepo *Char
 
 	chartFromRepoMaintainers := map[string]bool{}
 	for _, m := range chartFromRepo.Maintainers {
-		chartFromRepoMaintainers[m.Email+";"+m.Name+";"+m.URL] = true
+		chartFromRepoMaintainers[m.Name] = true
 	}
 	for _, m := range currentChartMeta.Maintainers {
-		if !chartFromRepoMaintainers[m.Email+";"+m.Name+";"+m.URL] {
+		if !chartFromRepoMaintainers[m.Name] {
 			return false
 		}
 	}

--- a/pkg/helm/findscore.go
+++ b/pkg/helm/findscore.go
@@ -90,11 +90,11 @@ func scoreChartSimilarity(release *release.Release, pkg ArtifactHubHelmPackage) 
 	}
 	pkgMaintainers := map[string]bool{}
 	for _, m := range pkg.Maintainers {
-		pkgMaintainers[m.Email+";"+m.Name+";"] = true
+		pkgMaintainers[m.Name] = true
 	}
 	matchedMaintainers := 0
 	for _, m := range release.Chart.Metadata.Maintainers {
-		if pkgMaintainers[m.Email+";"+m.Name+";"] {
+		if pkgMaintainers[m.Name] {
 			matchedMaintainers++
 		}
 	}

--- a/pkg/helm/findscore.go
+++ b/pkg/helm/findscore.go
@@ -106,6 +106,14 @@ func scoreChartSimilarity(release *release.Release, pkg ArtifactHubHelmPackage) 
 		klog.V(10).Infof("+1 score for %s verified publisher (ahub package repo %s)", release.Chart.Metadata.Name, pkg.Repository.Name)
 		ret++
 	}
+	if pkg.Official {
+		klog.V(10).Infof("+1 score for %s verified publisher (ahub package repo %s)", release.Chart.Metadata.Name, pkg.Repository.Name)
+		ret++
+	}
+	if pkg.Repository.Official {
+		klog.V(10).Infof("+1 score for %s verified publisher (ahub package repo %s)", release.Chart.Metadata.Name, pkg.Repository.Name)
+		ret++
+	}
 	if clusterVersionExistsInPackage(release.Chart.Metadata.Version, pkg) {
 		klog.V(10).Infof("+1 score for %s, current version exists in available versions (ahub package %s)", release.Chart.Metadata.Name, pkg.Repository.Name)
 		ret++


### PR DESCRIPTION
This PR fixes issues w/ ArtifactHub rate limiting by using the new cache API AH is providing for Nova

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Move to the new cached API

### What changes did you make?
Added and utilized a new "cached client"

I also removed some unused fields from the old struct, to help ensure that we're getting all the data we really need

### What alternative solution should we consider, if any?
* Make the old client usable via a flag?
* Cache the response locally to a file
