### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ meta:
 Install the golang binary and run it against your cluster.
 
 ```
-$ go get github.com/fairwindsops/nova
+$ go install github.com/fairwindsops/nova@latest
 $ nova find
 
 Release Name      Installed    Latest     Old       Deprecated


### PR DESCRIPTION
`go get` is no longer supported outside of a module. 

```
✗ go version
go version go1.20.3 darwin/arm64
```

```
▶  go get github.com/fairwindsops/nova
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.

✗ go install github.com/fairwindsops/nova
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/fairwindsops/nova@latest' to install the latest version
```


This PR fixes #

Out dated documentation for new go standards

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

