### PR TITLE
Allow custom timeout when fetching container tags

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,9 @@ Flags:
       --containers        Show old container image versions. There will be no helm output unless the --helm flag is set as well
       --helm              Show old helm releases. You can combine this flag with `--containers` to have both output in a single run.
   -h, --help              help for find
-      --show-non-semver   When finding container images, show all containers even if they don't follow semver.
+      --show-errored-containers   When finding container images, show errors encountered when scanning.
+      --show-non-semver           When finding container images, show all containers even if they don't follow semver.
+  -t, --timeout uint16            When finding container images, the time in seconds before canceling the operation. (default 10)
 
 Global Flags:
       --alsologtostderr                   log to standard error as well as files (default true)
@@ -105,6 +107,7 @@ redis             redis             redis             3              15.4.1     
 There are a couple flags that are unique to the container image output.
 - `--show-non-semver` will also show any container tags running in the cluster that do not have valid semver versions. By default these are not shown.
 - `--show-errored-containers` will show any containers that returned some sort of error when reaching out to the registry and/or when processing the tags.
+- `--timeout` will set the time (in seconds) before remote queries to the registry are cancelled. Useful when an image has many tags. Defaults to 10 seconds.
 
 Below is sample output for Nova when using the `--containers` flag
 


### PR DESCRIPTION
This PR fixes #234 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allows user to override the default timeout to overcome slow/large queries when fetching container tags.

### What changes did you make?
Added a new flag (`--timeout`/`-t`); use the value in `context.WithTimeout` instead of hard-coding it.

### What alternative solution should we consider, if any?
Initially I'd proposed setting a limit on the number of flags fetched, but that depends on getting the tags in reverse order. According to the [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-tags), "tags MUST be in lexical order (i.e. case-insensitive alphanumeric order)" so that's a non-starter 😅 

For my use case, setting the timeout to 20 seconds is enough to grab all ~9800 tags from [calico/node](https://quay.io/repository/calico/node?tab=tags) so one possibility would be to simply bump the default timeout in addition to (or instead of) this PR.

Alternatively, bumping the number of tags fetched in each batch or letting the user specify the batch size might also address the issue. A timeout feels more intuitive to me, though.

