### PR TITLE
Remove old install instructions

### DIFF
--- a/docs/contributing/guide.md
+++ b/docs/contributing/guide.md
@@ -21,7 +21,6 @@ Before you can contribute, you will need to sign the [Contributor License Agreem
 If you've encountered an issue that is not already reported, please create a [new issue](https://github.com/FairwindsOps/nova/issues), choose `Bug Report`, `Feature Request` or `Misc.` and follow the instructions in the template. 
 
 ## Getting Started
-
 We label issues with the ["good first issue" tag](https://github.com/FairwindsOps/nova/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 if we believe they'll be a good starting point for new contributors. If you're interested in working on an issue,
 please start a conversation on that issue, and we can help answer any questions as they come up.
@@ -31,13 +30,7 @@ please start a conversation on that issue, and we can help answer any questions 
 * A properly configured Golang environment with Go 1.11 or higher
 * A Kubernetes cluster defined in `~/.kube/config` (or in a file specified by the `KUBECONFIG` env variable)
 
-### Installation
-* Install the project with `go get github.com/fairwindsops/nova`
-* Change into the Nova directory which is installed at `$GOPATH/src/github.com/fairwindsops/nova`
-* See the results with `go run main.go find`
-
 ## Running Tests
-
 The following commands are all required to pass as part of testing:
 
 ```


### PR DESCRIPTION
This PR removes some `go get` instructions for dev setup that I think are obsolete thanks to go modules

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Remove old docs

### What changes did you make?

### What alternative solution should we consider, if any?

