### PR TITLE
remove deprecated ioutil references

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -184,7 +183,7 @@ func downloadConfig(cfgURL string) (string, error) {
 	segments := strings.Split(path, "/")
 	fileName := segments[len(segments)-1]
 
-	file, err := ioutil.TempFile("", fmt.Sprintf("*-%s", fileName))
+	file, err := os.CreateTemp("", fmt.Sprintf("*-%s", fileName))
 	if err != nil {
 		return "", err
 	}
@@ -380,7 +379,7 @@ func handleHelm(kubeContext string) (*output.Output, error) {
 		}
 		packages, err := ahClient.List()
 		if err != nil {
-			return nil, fmt.Errorf("Error getting artifacthub package repos: %v", err)
+			return nil, fmt.Errorf("error getting artifacthub package repos: %v", err)
 		}
 		klog.V(2).Infof("found %d possible package matches", len(packages))
 		for _, release := range releases {

--- a/pkg/helm/artifacthub_cached.go
+++ b/pkg/helm/artifacthub_cached.go
@@ -17,7 +17,6 @@ package helm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -108,7 +107,7 @@ func (ac *ArtifactHubCachedPackageClient) List() ([]ArtifactHubHelmPackage, erro
 			return nil, err
 		}
 	} else {
-		cache, err := ioutil.ReadFile(cacheFile)
+		cache, err := os.ReadFile(cacheFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/helm/chartrepo.go
+++ b/pkg/helm/chartrepo.go
@@ -16,7 +16,7 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -99,7 +99,7 @@ func (r *Repo) loadReleases() error {
 		return err
 	}
 
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -129,7 +128,7 @@ func (output Output) ToFile(filename string) error {
 			return err
 		}
 
-		err = ioutil.WriteFile(filename, data, 0644)
+		err = os.WriteFile(filename, data, 0644)
 		if err != nil {
 			klog.Errorf("Error writing to file %s: %v", filename, err)
 		}
@@ -397,7 +396,7 @@ func (output HelmAndContainersOutput) ToFile(filename string) error {
 			klog.Errorf("Error marshaling json: %v", err)
 			return err
 		}
-		err = ioutil.WriteFile(filename, data, 0644)
+		err = os.WriteFile(filename, data, 0644)
 		if err != nil {
 			klog.Errorf("Error writing to file %s: %v", filename, err)
 		}


### PR DESCRIPTION
This PR fixes the use of the now depracted `ioutil` package, replacing functions it provided with the according `os` or `io` functions.

## Checklist
* [X] I have signed the CLA
* [ ] I have updated/added any relevant documentation (not needed)

## Description
### What's the goal of this PR?
To remove any references to `ioutil` while ensuring the functionality that it provided is still in place with the newer alternatives.

### What changes did you make?
Changed all references as follows:
- `ioutil.TempFile` -> `os.CreateTemp`
- `ioutil.ReadFile` -> `os.ReadFile`
- `ioutil.ReadAll` -> `io.ReadAll`
- `ioutil.WriteFile` -> `os.WriteFile`

Also changed a capitalized `fmt.Errorf` message as per Go convention.

### What alternative solution should we consider, if any?
- Since the library is deprecated, if this change is omitted, there will eventually be issues with compatibility with newer versions of go.

