### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,5 +29,5 @@ brew install fairwindsops/tap/nova
 
 ### From source
 ```
-go get github.com/fairwindsops/nova
+go install github.com/fairwindsops/nova@latest
 ```


### PR DESCRIPTION
`go get` is deprecated for binaries.
Attempting to install like `go get github.com/fairwindsops/nova` results in this error:

```bash
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Instead, the new way to install binaries with go is `go install github.com/fairwindsops/nova@latest`. This works as before.


This PR fixes #

An error in the docs

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

To provide a out off the box working command for installing from source in the docs

### What changes did you make?

I changed `go get` to `go install`

### What alternative solution should we consider, if any?


I dont see any resonable alternatives.