### PR TITLE
feat: kubeconfig path flag

### DIFF
--- a/pkg/containers/images.go
+++ b/pkg/containers/images.go
@@ -93,9 +93,9 @@ type Tag struct {
 }
 
 // NewClient is a constructor to create a new Client
-func NewClient(kubeContext string) *Client {
+func NewClient(kubeContext, kubeConfigPath string) *Client {
 	return &Client{
-		Kube: kube.GetConfigInstance(kubeContext),
+		Kube: kube.GetConfigInstance(kubeContext, kubeConfigPath),
 	}
 }
 

--- a/pkg/helm/cluster.go
+++ b/pkg/helm/cluster.go
@@ -39,9 +39,9 @@ type DesiredVersion struct {
 }
 
 // NewHelm returns a basic helm struct with the version of helm requested
-func NewHelm(kubeContext string) *Helm {
+func NewHelm(kubeContext, kubeConfigPath string) *Helm {
 	return &Helm{
-		Kube: kube.GetConfigInstance(kubeContext),
+		Kube: kube.GetConfigInstance(kubeContext, kubeConfigPath),
 	}
 }
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -57,6 +57,7 @@ func GetConfigInstance(context, kubeConfigPath string) *Connection {
 	return kubeClient
 }
 
+// GetConfig returns a *rest.Config based on the current configuration
 func GetConfig(context, kubeConfigPath string) (*rest.Config, error) {
 
 	if context != "" {

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"flag"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -45,19 +46,37 @@ var (
 )
 
 // GetConfigInstance returns a Kubernetes interface based on the current configuration
-func GetConfigInstance(context string) *Connection {
+func GetConfigInstance(context, kubeConfigPath string) *Connection {
 	once.Do(func() {
 		kubeClient = &Connection{
-			Client:        getKubeClient(context),
-			DynamicClient: getDynamicKubeClient(context),
-			RESTMapper:    getRESTMapper(context),
+			Client:        getKubeClient(context, kubeConfigPath),
+			DynamicClient: getDynamicKubeClient(context, kubeConfigPath),
+			RESTMapper:    getRESTMapper(context, kubeConfigPath),
 		}
 	})
 	return kubeClient
 }
 
-func getKubeClient(context string) kubernetes.Interface {
-	kubeConf, err := config.GetConfigWithContext(context)
+func GetConfig(context, kubeConfigPath string) (*rest.Config, error) {
+
+	if context != "" {
+		klog.V(3).Infof("using kube context: %s", context)
+	}
+
+	fs := flag.NewFlagSet("fs", flag.ContinueOnError)
+	fs.String("kubeconfig", kubeConfigPath, "")
+	config.RegisterFlags(fs)
+
+	kubeConfig, err := config.GetConfigWithContext(context)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeConfig, nil
+}
+
+func getKubeClient(context, kubeConfigPath string) kubernetes.Interface {
+	kubeConf, err := GetConfig(context, kubeConfigPath)
 	if err != nil {
 		klog.Fatalf("error getting config with context %s: %v", context, err)
 	}
@@ -69,8 +88,8 @@ func getKubeClient(context string) kubernetes.Interface {
 	return clientset
 }
 
-func getDynamicKubeClient(context string) dynamic.Interface {
-	kubeConf, err := config.GetConfigWithContext(context)
+func getDynamicKubeClient(context, kubeConfigPath string) dynamic.Interface {
+	kubeConf, err := GetConfig(context, kubeConfigPath)
 	if err != nil {
 		klog.Fatalf("error getting config with context %s: %v", context, err)
 	}
@@ -81,8 +100,8 @@ func getDynamicKubeClient(context string) dynamic.Interface {
 	return dynamicClient
 }
 
-func getRESTMapper(context string) meta.RESTMapper {
-	kubeConf, err := config.GetConfigWithContext(context)
+func getRESTMapper(context, kubeConfigPath string) meta.RESTMapper {
+	kubeConf, err := GetConfig(context, kubeConfigPath)
 	if err != nil {
 		klog.Fatalf("error getting config with context %s: %v", context, err)
 	}


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Adds the a kubeconfig flag to the nova command, so kubeconfig file paths can be used.

### What changes did you make?
Added the kubeconfig flag, and included it as an option when generating the Kubernetes client config.

### What alternative solution should we consider, if any?

