### PR TITLE
Don't send things that aren't errors to stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,10 +50,6 @@ func init() {
 		genConfigCmd,
 	)
 
-	rootCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
-		os.Stderr.WriteString("\n\nWant more? Automate Nova for free with Fairwinds Insights!\n🚀 https://fairwinds.com/insights-signup/nova 🚀\n")
-	}
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file to use. If empty, flags will be used instead")
 	rootCmd.PersistentFlags().String("output-file", "", "Path on local filesystem to write file output to")
 	err := viper.BindPFlag("output-file", rootCmd.PersistentFlags().Lookup("output-file"))


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To stop things that clearly aren't errors being printed to the error output

### What changes did you make?
Deleted some kind of advertising

### What alternative solution should we consider, if any?
Not spamming stderr

