### PR TITLE
fix: honor -stderrthreshold by opting out of legacy klog behavior

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,6 +157,11 @@ func init() {
 	}
 
 	klog.InitFlags(nil)
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default).
+	// Ref: kubernetes/klog#212, kubernetes/klog#432
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 	_ = flag.Set("alsologtostderr", "true")
 	_ = flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlag(flag.Lookup("alsologtostderr"))


### PR DESCRIPTION
## Summary

klog v2 defaults `-logtostderr=true`, which causes the `-stderrthreshold` flag
to be silently ignored ([kubernetes/klog#212](https://github.com/kubernetes/klog/issues/212)).
This means users cannot control which severity levels are routed to stderr.

klog **v2.140.0** introduced the `legacy_stderr_threshold_behavior` flag to fix
this ([kubernetes/klog#432](https://github.com/kubernetes/klog/pull/432)).
Nova already depends on klog v2.140.0, so the fix only requires opting in.

## What changed

In `cmd/root.go`, right after `klog.InitFlags(nil)` and **before** the existing
`flag.Set` calls, two new flags are set:

```go
_ = flag.Set("legacy_stderr_threshold_behavior", "false")
_ = flag.Set("stderrthreshold", "INFO")
```

- `legacy_stderr_threshold_behavior=false` — tells klog to respect
  `-stderrthreshold` even when `-logtostderr=true`.
- `stderrthreshold=INFO` — routes INFO and above to stderr (matching the
  current effective behavior, now explicitly declared).

## Why

Without this change, passing `-stderrthreshold=WARNING` (or any other value) to
Nova has no effect — all log levels still go to stderr because `-logtostderr`
overrides everything. After this change, users can filter stderr output by
severity as intended.

## References

- Upstream issue: [kubernetes/klog#212](https://github.com/kubernetes/klog/issues/212)
- Upstream fix: [kubernetes/klog#432](https://github.com/kubernetes/klog/pull/432)