### PR TITLE
Update CircleCI configuration to use GCP Docker login instead of Quay.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,10 @@ jobs:
       - *install_vault_machine
       - rok8s/get_vault_env:
           vault_path: repo/global/env
-      - rok8s/docker_login:
-          registry: "quay.io"
-          username: $FAIRWINDS_QUAY_USER
-          password-variable: FAIRWINDS_QUAY_TOKEN
+      - run:
+          name: docker login
+          command: |
+            docker login -u _json_key -p "$(echo $GCP_ARTIFACTREADWRITE_JSON_KEY | base64 -d)" us-docker.pkg.dev
       - *setup_qemu_binfmt
       - run:
           name: Run GoReleaser release


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

